### PR TITLE
Solve issue #5

### DIFF
--- a/server.py
+++ b/server.py
@@ -11,6 +11,8 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 filter_param = query_components.get("filter")[0]
                 cmd.append(filter_param)
             output = subprocess.Popen(cmd, stdout=subprocess.PIPE).communicate()[0]
+            self.send_response(200)
+            self.end_headers()
             self.wfile.write(output)             
         else:
             SimpleHTTPServer.SimpleHTTPRequestHandler.do_GET(self)


### PR DESCRIPTION
The server does not return a valid 200 response nor does it properly
format the header.  This results in the inability to view the tasks in
the calendar.  This patch fixes these issues by calling
`send_response(200)` and  `end_headers()` before sending the reply.